### PR TITLE
Add url to topic returned by pact.request

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ function request(req) {
             }
             vow.callback(err, {
                 body: results,
+                options: options,
                 status: res.statusCode,
                 headers: res.headers
             });


### PR DESCRIPTION
This adds options (including request URL) to support using the URL derived from the test context name. Having the URL as part of the topic allows building some nice contextual tests and helps keep tests DRY.

What do you think about including this in the next rev?
